### PR TITLE
Fixes #5 by using the right growth rate formula.

### DIFF
--- a/cloudwatch.go
+++ b/cloudwatch.go
@@ -62,10 +62,10 @@ func (self Request) Measure() (Metrics, error) {
 	metrics.TotalObjectCount = objectMetrics[len(objectMetrics)-1].Total
 
 	// calculate growth
-	metrics.SizeGrowthMonthly = monthlyGrowth(sizeMetrics)
-	metrics.ObjectGrowthMonthly = monthlyGrowth(objectMetrics)
-	metrics.SizeGrowthYearly = yearlyGrowth(sizeMetrics)
-	metrics.ObjectGrowthYearly = yearlyGrowth(objectMetrics)
+	metrics.SizeGrowthMonthly = monthlyGrowthPct(sizeMetrics)
+	metrics.ObjectGrowthMonthly = monthlyGrowthPct(objectMetrics)
+	metrics.SizeGrowthYearly = yearlyGrowthPct(sizeMetrics)
+	metrics.ObjectGrowthYearly = yearlyGrowthPct(objectMetrics)
 
 	return metrics, nil
 }

--- a/growth.go
+++ b/growth.go
@@ -1,39 +1,83 @@
 package bucketgrowth
 
 import (
-	"math"
+  "fmt"
+  "log"
+  "time"
 )
+
+// Custom error for when a metric isn't found in an array of metrics
+var ErrDailyMetricNotFound error = fmt.Errorf("Metric not found")
 
 // Returns the decimal value that equates to unit/month
 // Assumes array in already sorted by time (oldest->newest)
-func monthlyGrowth(metrics []DailyMetric) float64 {
-	presentDate := metrics[len(metrics)-1].Date
-	originalDate := presentDate.AddDate(0, -1, 0)
+func monthlyGrowthPct(metrics []DailyMetric) float64 {
+  var monthlyGrowthRates [12]float64
 
-	idx := 0
-	for i, metric := range metrics {
-		if metric.Date == originalDate {
-			idx = i
+  for i, ending := 0, metrics[len(metrics)-1]; i < 12; i++ {
+    var starting DailyMetric
+    startingDate := ending.Date.AddDate(0, -1, 0)
+    starting, err := findMetricByDate(metrics, startingDate)
+    if err != nil {
+      starting = metrics[0]
+    }
+    log.Printf("[monthlyGrowth] Starting Date: %s\n", starting.Date)
+    log.Printf("[monthlyGrowth] Ending Date: %s\n", ending.Date)
+    growthRate := midpointGrowthRate(starting, ending)
+
+    monthlyGrowthRates[12-1-i] = growthRate
+    ending = starting
+  }
+
+  log.Printf("Growth rates: %v\n", monthlyGrowthRates)
+
+  avgMonthlyGrowthRate := average(monthlyGrowthRates[:])
+
+  log.Printf("[monthlyGrowth] Growth rate: %f\n", avgMonthlyGrowthRate)
+
+  return avgMonthlyGrowthRate * 100
+}
+
+func average(metrics []float64) float64 {
+  var sum float64
+  for _, val := range metrics {
+    sum += val
+  }
+
+  return sum / float64(len(metrics))
+}
+
+func findMetricByDate(metrics []DailyMetric, date time.Time) (DailyMetric, error) {
+  var metric DailyMetric
+	for i, val := range metrics {
+		if val.Date == date {
+      metric = metrics[i]
 			break
 		}
 	}
 
-	presentValue := metrics[len(metrics)-1].Total
-	originalValue := metrics[idx].Total
+  if metric == (DailyMetric{}) {
+    return DailyMetric{}, ErrDailyMetricNotFound
+  }
 
-	growthRate := (presentValue - originalValue) / originalValue
-	return float64(growthRate * 100)
+  return metric, nil
 }
 
 // Returns the decimal value that equates to unit/year
 // Assumes array in already sorted by time (oldest->newest)
-func yearlyGrowth(metrics []DailyMetric) float64 {
-	// Growth Rate = (Present / Past) * 1/N - 1
-	presentValue := metrics[len(metrics)-1].Total
-	originalValue := metrics[0].Total
+func yearlyGrowthPct(metrics []DailyMetric) float64 {
+  ending := metrics[len(metrics)-1]
+  starting := metrics[0]
 
-	diff := len(metrics) - 1
-	growthRate := (math.Pow(float64(presentValue-originalValue), float64(1/diff)) - 1)
+  log.Printf("[yearlyGrowth] Starting value: %d\n", starting.Total)
+  log.Printf("[yearlyGrowth] Ending value: %d\n", ending.Total)
+
+  growthRate := midpointGrowthRate(starting, ending)
+  log.Printf("[yearlyGrowth] Growth rate: %f\n", growthRate)
 
 	return float64(growthRate * 100)
+}
+
+func midpointGrowthRate(starting, ending DailyMetric) float64 {
+	return float64(ending.Total - starting.Total)/float64((starting.Total + ending.Total)/2)
 }

--- a/growth_test.go
+++ b/growth_test.go
@@ -1,16 +1,51 @@
 package bucketgrowth
 
 import (
+  "log"
+  "io/ioutil"
+  "math"
 	"testing"
 	"time"
 )
 
-func TestMonthlyGrowth(t *testing.T) {
+func init() {
+  log.SetOutput(ioutil.Discard)
+}
+
+func TestAverage(t *testing.T) {
+  cases := []struct{
+    name string
+    metrics []float64
+    expected float64
+  }{
+    {
+      "valid result",
+      []float64{ float64(1), float64(2), },
+      float64(1.5),
+    },
+  }
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := average(c.metrics)
+
+			if c.expected != actual {
+				t.Fatalf("Expected %v but got %v", c.expected, actual)
+			}
+		})
+	}
+}
+
+func TestMonthlyGrowthPct(t *testing.T) {
 	now := time.Now()
 	metrics := []DailyMetric{
 		{
-			Date:  now.AddDate(0, -1, 0),
+			Date:  now.AddDate(0, -2, 0),
 			Total: 100,
+		},
+		{
+			Date:  now.AddDate(0, -1, 0),
+			Total: 200,
 		},
 		{
 			Date:  now,
@@ -18,15 +53,18 @@ func TestMonthlyGrowth(t *testing.T) {
 		},
 	}
 
-	expected := float64(900)
-	actual := monthlyGrowth(metrics)
+	expected := float64(16.67)
+	actual := monthlyGrowthPct(metrics)
+  // due to floating-point precision, we need to round in order to pass
+  // this test.
+  actual = math.Round(actual*100)/100
 
 	if expected != actual {
 		t.Fatalf("Expected %v but got %v", expected, actual)
 	}
 }
 
-func TestYearlyGrowth(t *testing.T) {
+func TestYearlyGrowthPct(t *testing.T) {
 	now := time.Now()
 	metrics := []DailyMetric{
 		{
@@ -43,10 +81,107 @@ func TestYearlyGrowth(t *testing.T) {
 		},
 	}
 
-	expected := float64(9900)
-	actual := yearlyGrowth(metrics)
+	expected := float64(196.04)
+	actual := yearlyGrowthPct(metrics)
+  // due to floating-point precision, we need to round in order to pass
+  // this test.
+  actual = math.Round(actual*100)/100
 
 	if expected != actual {
 		t.Fatalf("Expected %v but got %v", expected, actual)
+	}
+}
+
+func TestMidpointGrowthRate(t *testing.T) {
+  cases := []struct{
+    name string
+    start DailyMetric
+    end DailyMetric
+    expected float64
+  }{
+    {
+      "valid result",
+      DailyMetric{
+        Total: 100,
+      },
+      DailyMetric{
+        Total: 1000,
+      },
+      float64(1.63636),
+    },
+  }
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := midpointGrowthRate(c.start,c.end)
+      actual = math.Round(actual*100000)/100000
+
+			if c.expected != actual {
+				t.Fatalf("Expected %v but got %v", c.expected, actual)
+			}
+		})
+	}
+}
+
+func TestFindMetricByDate(t *testing.T) {
+  now := time.Now()
+
+  cases := []struct{
+    name string
+    metrics []DailyMetric
+    date time.Time
+    expected DailyMetric
+    expectedErr error
+  }{
+    {
+      "valid result",
+      []DailyMetric{
+        DailyMetric{
+          Date: now.AddDate(0,-8,0),
+        },
+        DailyMetric{
+          Date: now.AddDate(0,-6,0),
+        },
+        DailyMetric{
+          Date: now,
+        },
+      },
+      now.AddDate(0,-6,0),
+      DailyMetric{
+        Date: now.AddDate(0,-6,0),
+      },
+      nil,
+    },
+    {
+      "date not found",
+      []DailyMetric{
+        DailyMetric{
+          Date: now.AddDate(0,-8,0),
+        },
+        DailyMetric{
+          Date: now.AddDate(0,-6,0),
+        },
+        DailyMetric{
+          Date: now,
+        },
+      },
+      now.AddDate(0,-7,0),
+      DailyMetric{},
+      ErrDailyMetricNotFound,
+    },
+  }
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual, err := findMetricByDate(c.metrics,c.date)
+
+      if c.expectedErr != err {
+				t.Fatalf("Expected %v but got %v", c.expectedErr, err)
+      }
+
+			if c.expected != actual {
+				t.Fatalf("Expected %v but got %v", c.expected, actual)
+			}
+		})
 	}
 }


### PR DESCRIPTION
# Overview

This uses the correct formula for growth rate calculations using historical data, midpoint growth rates.  It was originally using CAGR, but that is for future growth projections.

# Rollback

No rollback possible.  The code is now using the right formula.

# Checklist

* [x] PR subject line is prefixed with a ticket ID
* [x] PR has a label set
* [x] All sections of the PR have been filled out.