### PR TITLE
Closing #9 by adding --skip-banner flag to suppress banner during output

### DIFF
--- a/cmd/bucketgrowth/core.go
+++ b/cmd/bucketgrowth/core.go
@@ -71,8 +71,10 @@ func displayMetrics(metrics bucketgrowth.Metrics) error {
 	}
 
 	if flagOutputType == outputText {
-		fmt.Println("Bucket Growth")
-		fmt.Println("=============")
+		if !flagSkipBanner {
+			fmt.Println("Bucket Growth")
+			fmt.Println("=============")
+		}
 
 		fmt.Printf("Total Size: %s\n", humanize.Bytes(uint64(metrics.TotalSizeBytes)))
 		fmt.Printf("Total Objects: %s\n", humanize.Comma(metrics.TotalObjectCount))

--- a/cmd/bucketgrowth/flag.go
+++ b/cmd/bucketgrowth/flag.go
@@ -18,6 +18,8 @@ var flagVerbose bool
 
 var flagOutputType string
 
+var flagSkipBanner bool
+
 var ErrUnsupportedOutputType error = errors.New("Unsupported output type")
 
 var validOutputTypes []string = []string{outputText, outputJson}

--- a/cmd/bucketgrowth/main.go
+++ b/cmd/bucketgrowth/main.go
@@ -40,6 +40,11 @@ func main() {
 				Value:       outputText,
 				Destination: &flagOutputType,
 			},
+			&cli.BoolFlag{
+				Name:        "skip-banner",
+				Usage:       "Suppresses output of the banner",
+				Destination: &flagSkipBanner,
+			},
 		},
 	}
 


### PR DESCRIPTION
# Overview

Adds a `--skip-banner` flag to the command so that the banner is suppressed during output.

# Rollback

Revert the PR.

# Checklist

* [x] PR subject line is prefixed with a ticket ID
* [x] PR has a label set
* [x] All sections of the PR have been filled out.
