### PR TITLE
Closing #7 by adding 1-year and 5-year growth projections

### DIFF
--- a/cloudwatch.go
+++ b/cloudwatch.go
@@ -22,6 +22,16 @@ type Metrics struct {
 
 	ObjectGrowthMonthly float64 `json:"object_growth_monthly"`
 	ObjectGrowthYearly  float64 `json:"object_growth_yearly"`
+
+  Projections ProjectionMetrics `json:"projections"`
+}
+
+type ProjectionMetrics struct {
+  Size1Year int64 `json:"size_bytes_1_year"`
+  Size5Year int64 `json:"size_bytes_5_year"`
+
+  Object1Year int64 `json:"object_count_1_year"`
+  Object5Year int64 `json:"object_count_5_year"`
 }
 
 type DailyMetric struct {
@@ -66,6 +76,18 @@ func (self Request) Measure() (Metrics, error) {
 	metrics.ObjectGrowthMonthly = monthlyGrowthPct(objectMetrics)
 	metrics.SizeGrowthYearly = yearlyGrowthPct(sizeMetrics)
 	metrics.ObjectGrowthYearly = yearlyGrowthPct(objectMetrics)
+
+  // calculation projection
+  // using monthly growth rate because it is more accurate than yearly
+  proj := ProjectionMetrics{}
+
+  proj.Size1Year = projection(metrics.TotalSizeBytes, 1, metrics.SizeGrowthMonthly / 100.0)
+  proj.Object1Year = projection(metrics.TotalObjectCount, 1, metrics.ObjectGrowthMonthly / 100.0)
+
+  proj.Size5Year = projection(metrics.TotalSizeBytes, 5, metrics.SizeGrowthMonthly / 100.0)
+  proj.Object5Year = projection(metrics.TotalObjectCount, 5, metrics.ObjectGrowthMonthly / 100.0)
+
+  metrics.Projections = proj
 
 	return metrics, nil
 }

--- a/cmd/bucketgrowth/core.go
+++ b/cmd/bucketgrowth/core.go
@@ -76,11 +76,15 @@ func displayMetrics(metrics bucketgrowth.Metrics) error {
 			fmt.Println("=============")
 		}
 
-		fmt.Printf("Total Size: %s\n", humanize.Bytes(uint64(metrics.TotalSizeBytes)))
+		fmt.Printf("\nTotal Size: %s\n", humanize.Bytes(uint64(metrics.TotalSizeBytes)))
 		fmt.Printf("Total Objects: %s\n", humanize.Comma(metrics.TotalObjectCount))
-		fmt.Println("")
-		fmt.Printf("Size Growth: %s%%/mo, %s%%/yr\n", humanize.CommafWithDigits(metrics.SizeGrowthMonthly, 2), humanize.CommafWithDigits(metrics.SizeGrowthYearly, 2))
+
+		fmt.Printf("\nSize Growth: %s%%/mo, %s%%/yr\n", humanize.CommafWithDigits(metrics.SizeGrowthMonthly, 2), humanize.CommafWithDigits(metrics.SizeGrowthYearly, 2))
 		fmt.Printf("Object Growth: %s%%/mo, %s%%/yr\n", humanize.CommafWithDigits(metrics.ObjectGrowthMonthly, 2), humanize.CommafWithDigits(metrics.ObjectGrowthYearly, 2))
+
+    fmt.Printf("\nSize Projection: %s (1 yr), %s (5 yr)\n", humanize.Bytes(uint64(metrics.Projections.Size1Year)), humanize.Bytes(uint64(metrics.Projections.Size5Year)))
+
+    fmt.Printf("Object Count Projection: %s (1 yr), %s (5 yr)\n", humanize.Comma(metrics.Projections.Object1Year), humanize.Comma(metrics.Projections.Object5Year))
 	}
 
 	return nil

--- a/projection.go
+++ b/projection.go
@@ -1,0 +1,27 @@
+package bucketgrowth
+
+import (
+  "math"
+)
+
+func projection(val int64, numYears int, monthlyGrowthRate float64) int64 {
+  if numYears == 0 {
+    return 0.0
+  }
+
+  if val == 0 {
+    return 0.0
+  }
+
+  if monthlyGrowthRate == 0.0 {
+    return val
+  }
+
+  periods := numYears * 12
+
+  // value * (1 + rate)^periods
+  compoundGrowthRate := math.Pow((1 + monthlyGrowthRate),float64(periods))
+
+  result := float64(val) * compoundGrowthRate
+  return int64(result)
+}

--- a/projection_test.go
+++ b/projection_test.go
@@ -1,0 +1,54 @@
+package bucketgrowth
+
+import (
+  "testing"
+)
+
+func TestProjection(t *testing.T) {
+  cases := []struct{
+    name string
+    val int64
+    numYears int
+    monthlyGrowthRate float64
+    expected int64
+  }{
+    {
+      "happy path",
+      1000,
+      1,
+      0.1,
+      3138,
+    },
+    {
+      "invalid val",
+      0,
+      10,
+      0.1,
+      0,
+    },
+    {
+      "invalid year",
+      1000,
+      0,
+      0.1,
+      0,
+    },
+    {
+      "invalid monthlyGrowthRate",
+      1000,
+      10,
+      0.0,
+      1000,
+    },
+  }
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := projection(c.val, c.numYears, c.monthlyGrowthRate)
+
+			if c.expected != actual {
+				t.Fatalf("Expected %v but got %v", c.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Overview

Adds growth projections for both size and object count, in 1- and 5-year increments.

# Checklist

* [x] PR subject line is prefixed with a ticket ID
* [x] PR has a label set
* [x] All sections of the PR have been filled out.
